### PR TITLE
add_restart_from_partially_completed_tumours

### DIFF
--- a/alpaca/ALPACA_segment_solution_class.py
+++ b/alpaca/ALPACA_segment_solution_class.py
@@ -557,13 +557,29 @@ class SegmentSolution:
         else:
             self.segments_dir = f"{self.tumour_dir}/segments"
 
-    def save_output(self):
-        logger = self.logger
-        end_time = time.time()
+    def output_exists(self):
+        """
+        Checks if the output file already exists.
+        """
+        output_path = self.create_output_path()
+        return os.path.exists(output_path)
+
+    def create_output_path(self):
+        """
+        Creates the output path for the solution based on file name and options.
+        """
         output_name = "optimal_" + self.input_file_name.split("ALPACA_input_table_")[1]
         output_dir = self.config["preprocessing_config"]["output_directory"]
         output_path = os.path.join(output_dir, output_name)
+        return output_path
+
+    def save_output(self):
+        logger = self.logger
+        end_time = time.time()
+        output_path = self.create_output_path()
+        output_dir = os.path.dirname(output_path)
         os.makedirs(output_dir, exist_ok=True)
+        # discard diploid clone:
         assert self.optimal_solution is not None
         self.optimal_solution = self.optimal_solution[
             self.optimal_solution.clone != "diploid"
@@ -583,6 +599,6 @@ class SegmentSolution:
             self.optimal_solution["run_time_seconds"] = total_run_time
         self.optimal_solution.to_csv(output_path, index=False)
         if os.path.exists(output_path):
-            logger.info(f"Segment output created")
+            logger.info("Segment output created")
         else:
             logger.error(f"Output not saved to {output_path}")

--- a/alpaca/__main__.py
+++ b/alpaca/__main__.py
@@ -3,7 +3,6 @@ import os
 import sys
 from tqdm import tqdm
 from io import StringIO
-from datetime import datetime
 from alpaca.ALPACA_segment_solution_class import SegmentSolution
 from alpaca.utils import (
     show_version,
@@ -77,6 +76,14 @@ def run_alpaca():
     try:
         for input_file_name in config["preprocessing_config"]["input_files"]:
             SS = SegmentSolution(input_file_name, config, logger)
+            if (
+                not config["preprocessing_config"]["overwrite_output"]
+                and SS.output_exists()
+            ):
+                logger.warning(
+                    f"Output for {input_file_name} already exists. Use '--overwrite_output 1' option to overwrite existing output. Skipping this segment."
+                )
+                continue
             SS.run_iterations()
             SS.find_optimal_solution()
             SS.get_solution()
@@ -100,7 +107,7 @@ def run_alpaca():
                 output_filename="cn_change_to_ancestor.csv",
             )
             logger.info(
-                f"Analysis completed successfully. Output saved to: {SS.config["preprocessing_config"]["output_directory"]}"
+                f"""Analysis completed successfully. Output saved to: {SS.config["preprocessing_config"]["output_directory"]}"""
             )
         logger.info("Done")
     except Exception as e:

--- a/alpaca/make_configuration.py
+++ b/alpaca/make_configuration.py
@@ -45,7 +45,15 @@ def get_parser():
         "--mode",
         type=str,
         default="tumour",
-        help="Mode of operation. If 'tumour', expect single file with all the segments and output a single file. If 'segment' expect array of files to segment files (can be from different tumours) and create separate outputs for each segment.",
+        help="Mode of operation. If 'tumour', expect single file with all the segments and output a single file.\
+            If 'segment' expect array of files to segment files (can be from different tumours) and create separate outputs for each segment.",
+    )
+    parser.add_argument(
+        "--overwrite_output",
+        type=int,
+        default=1,
+        help="If set to 0, ALPACA will check if solution file for each segment already exits, and will skip iteration if it does. \
+            If set to 1, ALPACA will overwrite existing solution files.",
     )
     parser.add_argument(
         "--output_directory",
@@ -160,6 +168,7 @@ def make_config(args_in):
     }
     preprocessing_config = {
         "mode": args.mode,
+        "overwrite_output": args.overwrite_output,
         "ci_table_name": args.ci_table_name,
         "debug": args.debug,
         "env": ENV,

--- a/alpaca/utils.py
+++ b/alpaca/utils.py
@@ -6,7 +6,6 @@ import importlib
 import logging
 from datetime import datetime
 from typing import Optional
-import logging
 
 
 def show_version():

--- a/tests/test_run_alpaca_correct_input.sh
+++ b/tests/test_run_alpaca_correct_input.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 tumour_id=LTX0000-Tumour1
-input_tumour_directory="test/correct_input/input/${tumour_id}"
-output_directory="test/correct_input/output/${tumour_id}"
+input_tumour_directory="examples/example_cohort/input/${tumour_id}"
+output_directory="tests/correct_input/output/${tumour_id}"
 
 # run alpaca:
 alpaca run \
     --input_tumour_directory "${input_tumour_directory}" \
-    --output_directory "${output_directory}"
+    --output_directory "${output_directory}" \
+    --overwrite_output 0


### PR DESCRIPTION
In the tumour mode, where ALPACA iterates sequentially over genomic segments and writes temporary solution files (separate csv file for each sgement), we now enable the option to restart solving a tumour if ALPACA timed out or errored for another reasosn. In such a case, instead of the final solution file, one can see multiple solution files, for each segment separately. If option "overwrite_output" is set to 0, ALPACA will skip segments with present solutions. Default of "overwrite_output" is 1.