### PR TITLE
Allow use of selected alternative trees

### DIFF
--- a/alpaca/scripts/submodules/alpaca_input_formatting/convert_conipher_output/convert_conipher_output.R
+++ b/alpaca/scripts/submodules/alpaca_input_formatting/convert_conipher_output/convert_conipher_output.R
@@ -176,6 +176,8 @@ extractTreeGraphPaths = function(tree_graph){
 option_list = list(
   make_option(c("--CONIPHER_tree_object"), type="character", 
               help="path to CONIPHER tree object"),
+  make_option(c("--CONIPHER_tree_index"), type="character",
+              help="selected CONIPHER tree index"),
   make_option(c("--output_dir"), type="character", 
               help="output directory")
 )
@@ -191,19 +193,20 @@ args = parse_args(parser)
 
 # Read the tree object and set output directory
 tree_object = readRDS(args$CONIPHER_tree_object)
+selected_tree_index = as.numeric(args$CONIPHER_tree_index)
 output_dir = args$output_dir
 
-default_tree = tree_object$graph_pyclone$default_tree
-tree_paths = extractTreeGraphPaths(tree_graph = default_tree)
+alt_trees = tree_object$graph_pyclone$alt_trees
+selected_tree = alt_trees[[selected_tree_index]]
+tree_paths = extractTreeGraphPaths(tree_graph = selected_tree)
 tree_path_clone_names = lapply(tree_paths, function(path){paste0('clone', path)})
 tree_json_path = sprintf('%s/tree_paths.json',output_dir)
 write(toJSON(tree_path_clone_names), tree_json_path)
 
-alt_trees = tree_object$graph_pyclone$alt_trees
 clonality_table = tree_object$clonality_out$clonality_table_corrected
 ccf_cluster_table = tree_object$nested_pyclone$ccf_cluster_table
 trunk = tree_object$graph_pyclone$trunk 
-cp_table = get_cp_table(alt_trees, 1, clonality_table, ccf_cluster_table, trunk)
+cp_table = get_cp_table(alt_trees, selected_tree_index, clonality_table, ccf_cluster_table, trunk)
 cp_table_path = sprintf('%s/cp_table.csv',output_dir)
 write.csv(cp_table, cp_table_path, row.names = FALSE)
 print('Done')

--- a/alpaca/scripts/submodules/alpaca_input_formatting/input_conversion.sh
+++ b/alpaca/scripts/submodules/alpaca_input_formatting/input_conversion.sh
@@ -10,6 +10,7 @@ usage() {
     echo "  --tumour_id              Tumour ID (required)"
     echo "  --refphase_rData         Path to refphase .RData file (required)"
     echo "  --CONIPHER_tree_object   Path to CONIPHER tree object .RDS file (required)"
+    echo "  --CONIPHER_tree_index    Selected CONIPHER tree index (optional, default: 1)"
     echo "  --output_dir             Output directory (required)"
     echo "  --help                   Display this help message"
     exit 1
@@ -21,6 +22,7 @@ while [[ "$#" -gt 0 ]]; do
         --tumour_id) tumour_id="$2"; shift ;;
         --refphase_rData) refphase_rData="$2"; shift ;;
         --CONIPHER_tree_object) CONIPHER_tree_object="$2"; shift ;;
+        --CONIPHER_tree_index) CONIPHER_tree_index="${2:-1}"; shift ;;
         --output_dir) output_dir="$2"; shift ;;
         --help) usage ;;
         *) echo "Unknown parameter passed: $1"; usage ;;
@@ -75,4 +77,5 @@ python3 "${SCRIPT_DIR}/convert_refphase_output/convert_refphase.py" \
 echo "Extracting data from CONIPHER output"
 Rscript "${SCRIPT_DIR}/convert_conipher_output/convert_conipher_output.R" \
     --CONIPHER_tree_object $CONIPHER_tree_object \
+    --CONIPHER_tree_index $CONIPHER_tree_index \
     --output_dir $output_dir


### PR DESCRIPTION
Instead of always using conipher default tree for input conversion, users can now select the tree by its index. Defaults to '1' i.e. conipher default tree